### PR TITLE
Simplify compact

### DIFF
--- a/Fred/Regex.fs
+++ b/Fred/Regex.fs
@@ -109,6 +109,19 @@ module Regex =
     | Cat (a, b)                 -> Cat (dP c a, b)
     | Star a                     -> Cat (dP c a, Star a)
 
+    // d returns the derivative of a parser of a regular language with respect to the input token c.
+    // That is, d returns a parser that accepts _the rest of the input except for the prefix token c_.
+    let rec d c = function
+    | Empty                      -> Empty
+    | Eps                        -> Empty
+    | Eps' _                     -> Empty
+    | Char x when x = c          -> Eps
+    | Char _                     -> Empty
+    | Union (a, b)               -> Union (d c a, d c b)
+    | Cat (a, b) when nullable a -> Union (d c b, Cat (d c a, b))
+    | Cat (a, b)                 -> Cat (d c a, b)
+    | Star a                     -> Cat (d c a, Star a)
+
     // interleave returns a sequence that draws elements from each of the sequences in turn.
     // As each sequence empties, interleave forgets about the sequence.
     // For instance interleave [Seq.ofList [1;2;3]; Seq.ofList [4;5;6]; Seq.empty; Seq.ofList [10;11]
@@ -218,18 +231,6 @@ module Regex =
                      | Star (Eps' _)          -> Eps
                      | Star _                 -> x)
 
-    // d returns the derivative of a parser of a regular language with respect to the input token c.
-    // That is, d returns a parser that accepts _the rest of the input except for the prefix token c_.
-    let rec d c = function
-    | Empty                      -> Empty
-    | Eps                        -> Empty
-    | Eps' _                     -> Empty
-    | Char x when x = c          -> Eps
-    | Char _                     -> Empty
-    | Union (a, b)               -> Union (d c a, d c b)
-    | Cat (a, b) when nullable a -> Union (d c b, Cat (d c a, b))
-    | Cat (a, b)                 -> Cat (d c a, b)
-    | Star a                     -> Cat (d c a, Star a)
 
     type Ident = int
     type State<'a> = {Ident: Ident; Token: 'a}

--- a/Fred/Regex.fs
+++ b/Fred/Regex.fs
@@ -279,7 +279,7 @@ module Regex =
         let draw' nfa (sb: StringBuilder) =
             let edges = nfa.Edges |> Map.toList
             edges
-            |> Seq.iter (fun (k,v) -> sb.AppendLine(sprintf "    %d [label=\"%A\"]" k.Ident k.Token) |> ignore)
+            |> Seq.iter (fun (k,_) -> sb.AppendLine(sprintf "    %d [label=\"%A\"]" k.Ident k.Token) |> ignore)
             edges
             |> Seq.iter (fun (src,dests) ->
                 dests

--- a/Fred/Regex.fs
+++ b/Fred/Regex.fs
@@ -104,6 +104,8 @@ module Regex =
                                     // part of the Union because it doesn't build parse
                                     // trees. Annoying that I don't know how to remove the
                                     // duplication of the rest of the functions!
+                                    // TODO: Maybe write dP, d as "named anonymous recursives",
+                                    // pull commonality into separate same thing, and >> them?
     | Cat (a, b) when nullable a -> Union (Cat (Eps' (parseNull a), dP c b),
                                            Cat (dP c a, b))
     | Cat (a, b)                 -> Cat (dP c a, b)

--- a/Fred/Regex.fs
+++ b/Fred/Regex.fs
@@ -194,7 +194,6 @@ module Regex =
     // map walks a regex parser in depth first order, running a function f on each
     // parser.
     let rec map f p =
-        printfn "walking %A" p
         match p with
         | Empty
         | Eps

--- a/FredTest/RegexCompactingTest.fs
+++ b/FredTest/RegexCompactingTest.fs
@@ -50,7 +50,8 @@ type ``Compacting``() =
     [<Test>]
     member __.``does not remove nullable trailing subparsers with partial parse trees``() =
         let p = (Cat (Char 'a', Cat ((Eps' (set [[]])), Cat ((Eps' (set [[]])), (Eps' (set [[]]))))))
-        parserEqual p (compact p)
+        // Compaction "coalesces" the Eps' nodes, but doesn't remove the final nullable coalesced node
+        parserEqual (Cat (Char 'a', Eps' (set [[]]))) (compact p)
     [<Test>]
     member __.``Nothing then something is something``() =
         parserEqual (Char 'a') (compact (Cat (Eps, Char 'a')))
@@ -72,6 +73,12 @@ type ``Compacting``() =
     [<Test>]
     member __.``compacts sequences of parsers``() =
         parserEqual (Cat (Char 'a', Char 'b')) (compact (Cat (Cat (Eps, Char 'a'), Cat(Eps, Char 'b'))))
+    [<Test>]
+    member __.``of a Cat of Eps' parsers combines the Eps' parsers``() =
+        parserEqual (Eps' (set [['a';'b']])) (compact (Cat (Eps' (set [['a']]), Eps' (set [['b']]))))
+    [<Test>]
+    member __.``of a Union of Eps' parsers combines the Eps' parsers``() =
+        parserEqual (Eps' (set [['a'];['b']])) (compact (Union (Eps' (set [['a']]), Eps' (set [['b']]))))
     [<Test>]
     member __.``of Star of Eps is Eps``() =
         parserEqual Eps (compact (Star Eps))

--- a/FredTest/RegexDerivingTest.fs
+++ b/FredTest/RegexDerivingTest.fs
@@ -113,10 +113,9 @@ type ``Deriving parse trees``() =
 //    [<Test>]
 //    member __.``Except for Char->Eps, both derivations are equal``() =
 //        let id = fun x -> x
-//        let idmerge = fun x a b -> x
 //        let parserToList p =
 //            let acc = ref []
-//            postfixWalk (fun x -> acc := x::(!acc); x) idmerge p |> ignore
+//            map (fun x -> acc := x::(!acc); x) p |> ignore
 //            !acc
 //        let nearlyEqual a b =
 //            let xs = parserToList a


### PR DESCRIPTION
Pull the mapping aspect of compaction away from the recursion part. Also, we can coalesce Eps' nodes under some conditions - a Cat of two Eps' nodes is an Eps' where the sets of parses are glommed together; a Union of two Eps' nodes is the set union of the two parse sets.

Turns out both of those are defined by parseNull.
